### PR TITLE
Fix `github.ref` check for concurrency settings

### DIFF
--- a/.github/workflows/rolling-abi-compatibility.yml
+++ b/.github/workflows/rolling-abi-compatibility.yml
@@ -6,9 +6,9 @@ on:
       - main
 
 concurrency:
-  # cancel previous runs of the same workflow, except for pushes on main branch
+  # cancel previous runs of the same workflow, except for pushes on given branches
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   abi_check:

--- a/.github/workflows/rolling-binary-build.yml
+++ b/.github/workflows/rolling-binary-build.yml
@@ -15,9 +15,9 @@ on:
     - cron: '03 1 * * MON-FRI'
 
 concurrency:
-  # cancel previous runs of the same workflow, except for pushes on main branch
+  # cancel previous runs of the same workflow, except for pushes on given branches
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   binary:

--- a/.github/workflows/rolling-compatibility-humble-binary-build.yml
+++ b/.github/workflows/rolling-compatibility-humble-binary-build.yml
@@ -12,9 +12,9 @@ on:
       - main
 
 concurrency:
-  # cancel previous runs of the same workflow, except for pushes on main branch
+  # cancel previous runs of the same workflow, except for pushes on given branches
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   build-on-humble:

--- a/.github/workflows/rolling-compatibility-jazzy-binary-build.yml
+++ b/.github/workflows/rolling-compatibility-jazzy-binary-build.yml
@@ -12,9 +12,9 @@ on:
       - main
 
 concurrency:
-  # cancel previous runs of the same workflow, except for pushes on master branch
+  # cancel previous runs of the same workflow, except for pushes on given branches
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   build-on-jazzy:

--- a/.github/workflows/rolling-compatibility-kilted-binary-build.yml
+++ b/.github/workflows/rolling-compatibility-kilted-binary-build.yml
@@ -12,9 +12,9 @@ on:
       - main
 
 concurrency:
-  # cancel previous runs of the same workflow, except for pushes on main branch
+  # cancel previous runs of the same workflow, except for pushes on given branches
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   build-on-kilted:

--- a/.github/workflows/rolling-coverage-build.yml
+++ b/.github/workflows/rolling-coverage-build.yml
@@ -9,9 +9,9 @@ on:
       - main
 
 concurrency:
-  # cancel previous runs of the same workflow, except for pushes on main branch
+  # cancel previous runs of the same workflow, except for pushes on given branches
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   coverage_rolling:

--- a/.github/workflows/rolling-debian-build.yml
+++ b/.github/workflows/rolling-debian-build.yml
@@ -9,9 +9,9 @@ on:
     - cron: '33 2 * * MON-FRI'
 
 concurrency:
-  # cancel previous runs of the same workflow, except for pushes on main branch
+  # cancel previous runs of the same workflow, except for pushes on given branches
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   debian_semi_binary_build:

--- a/.github/workflows/rolling-rhel-semi-binary-build.yml
+++ b/.github/workflows/rolling-rhel-semi-binary-build.yml
@@ -9,9 +9,9 @@ on:
     - cron: '42 4 * * MON-FRI'
 
 concurrency:
-  # cancel previous runs of the same workflow, except for pushes on main branch
+  # cancel previous runs of the same workflow, except for pushes on given branches
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   rhel_semi_binary_build:

--- a/.github/workflows/rolling-semi-binary-build.yml
+++ b/.github/workflows/rolling-semi-binary-build.yml
@@ -14,9 +14,9 @@ on:
     - cron: '33 1 * * MON-FRI'
 
 concurrency:
-  # cancel previous runs of the same workflow, except for pushes on main branch
+  # cancel previous runs of the same workflow, except for pushes on given branches
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   semi_binary:

--- a/.github/workflows/rolling-source-build.yml
+++ b/.github/workflows/rolling-source-build.yml
@@ -9,9 +9,9 @@ on:
     - cron: '03 3 * * MON-FRI'
 
 concurrency:
-  # cancel previous runs of the same workflow, except for pushes on main branch
+  # cancel previous runs of the same workflow, except for pushes on given branches
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   source:


### PR DESCRIPTION
`github.ref`:
> The ref given is fully-formed, meaning that for branches the format is refs/heads/<branch_name>.

which means the leading slash was wrong, see [this canceled job for example](https://github.com/ros-controls/kinematics_interface/actions/runs/17260587722).

https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#github-context