### PR TITLE
Rename shadowed variables

### DIFF
--- a/joint_state_topic_hardware_interface/include/joint_state_topic_hardware_interface/joint_state_topic_hardware_interface.hpp
+++ b/joint_state_topic_hardware_interface/include/joint_state_topic_hardware_interface/joint_state_topic_hardware_interface.hpp
@@ -67,8 +67,8 @@ private:
   std::vector<MimicJoint> mimic_joints_;
 
   /// The size of this vector is (standard_interfaces_.size() x nr_joints)
-  std::vector<std::vector<double>> joint_commands_;
-  std::vector<std::vector<double>> joint_states_;
+  std::vector<std::vector<double>> joint_command_values_;
+  std::vector<std::vector<double>> joint_state_values_;
 
   // If the difference between the current joint state and joint command is less than this value,
   // the joint command will not be published.


### PR DESCRIPTION
```
In file included from /workspaces/ros2_rolling_ws/src/topic_based_hardware_interfaces/joint_state_topic_hardware_interface/src/joint_state_topic_hardware_interface.cpp:25:
/workspaces/ros2_rolling_ws/src/topic_based_hardware_interfaces/joint_state_topic_hardware_interface/include/joint_state_topic_hardware_interface/joint_state_topic_hardware_interface.hpp:71:36: error: non-static data member 'joint_states_' of 'JointStateTopicSystem' shadows member inherited from type 'HardwareComponentInterface' [-Werror,-Wshadow-field]
   71 |   std::vector<std::vector<double>> joint_states_;
      |                                    ^
/workspaces/ros2_rolling_ws/install/hardware_interface/include/hardware_interface/hardware_interface/hardware_component_interface.hpp:788:42: note: declared here
  788 |   std::vector<StateInterface::SharedPtr> joint_states_;
      |                                          ^
```

Fixes #35, #36