### PR TITLE
Add alias for old topic_based_ros2_control

### DIFF
--- a/joint_state_topic_hardware_interface/joint_state_topic_hardware_interface_plugin_description.xml
+++ b/joint_state_topic_hardware_interface/joint_state_topic_hardware_interface_plugin_description.xml
@@ -8,4 +8,14 @@
       ros2_control hardware interface for JointState topic based control.
     </description>
   </class>
+  <class
+    name="topic_based_ros2_control/TopicBasedSyste"
+    type="joint_state_topic_hardware_interface::JointStateTopicSystem"
+    base_class_type="hardware_interface::SystemInterface"
+  >
+    <description>
+      ros2_control hardware interface for JointState topic based control.
+      Deprecated: change to 'joint_state_topic_hardware_interface/JointStateTopicSystem'
+    </description>
+  </class>
 </library>

--- a/joint_state_topic_hardware_interface/joint_state_topic_hardware_interface_plugin_description.xml
+++ b/joint_state_topic_hardware_interface/joint_state_topic_hardware_interface_plugin_description.xml
@@ -9,7 +9,7 @@
     </description>
   </class>
   <class
-    name="topic_based_ros2_control/TopicBasedSyste"
+    name="topic_based_ros2_control/TopicBasedSystem"
     type="joint_state_topic_hardware_interface::JointStateTopicSystem"
     base_class_type="hardware_interface::SystemInterface"
   >

--- a/joint_state_topic_hardware_interface/joint_state_topic_hardware_interface_plugin_description.xml
+++ b/joint_state_topic_hardware_interface/joint_state_topic_hardware_interface_plugin_description.xml
@@ -8,6 +8,7 @@
       ros2_control hardware interface for JointState topic based control.
     </description>
   </class>
+  <!-- For Backward Compatibility Reasons. TODO: Remove in future releases -->
   <class
     name="topic_based_ros2_control/TopicBasedSystem"
     type="joint_state_topic_hardware_interface::JointStateTopicSystem"

--- a/joint_state_topic_hardware_interface/src/joint_state_topic_hardware_interface.cpp
+++ b/joint_state_topic_hardware_interface/src/joint_state_topic_hardware_interface.cpp
@@ -83,6 +83,16 @@ CallbackReturn JointStateTopicSystem::on_init(const hardware_interface::Hardware
     sum_wrapped_joint_states_ = true;
   }
 
+  // TODO(anyone): Remove in a future release after users have migrated to the new plugin name
+  if (get_hardware_info().hardware_plugin_name.find("topic_based_ros2_control") != std::string::npos)
+  {
+    RCLCPP_WARN(get_node()->get_logger(),
+                "Plugin name '%s' is deprecated, upgrade to "
+                "'joint_state_topic_hardware_interface/JointStateTopicSystem' from package"
+                " 'joint_state_topic_hardware_interface' instead.",
+                get_hardware_info().hardware_plugin_name.c_str());
+  }
+
   return CallbackReturn::SUCCESS;
 }
 


### PR DESCRIPTION
Not sure if this is helpful for migration like reported [here](https://github.com/ros-controls/ros2_control/issues/3019#issuecomment-3859836560)