### PR TITLE
Ensure all arrays in the JointState command message have the same size

### DIFF
--- a/joint_state_topic_hardware_interface/src/joint_state_topic_hardware_interface.cpp
+++ b/joint_state_topic_hardware_interface/src/joint_state_topic_hardware_interface.cpp
@@ -201,10 +201,11 @@ hardware_interface::return_type JointStateTopicSystem::write(const rclcpp::Time&
   // The JointState message definition requires that all arrays in the message
   // should have the same size, or be empty.
   // https://docs.ros.org/en/api/sensor_msgs/html/msg/JointState.html
+  typedef sensor_msgs::msg::JointState::_position_type::value_type value_type;
   joint_state.name.resize(joints.size());
-  joint_state.position.resize(joints.size(), 0.0);
-  joint_state.velocity.resize(joints.size(), 0.0);
-  joint_state.effort.resize(joints.size(), 0.0);
+  joint_state.position.resize(joints.size(), std::numeric_limits<value_type>::quiet_NaN());
+  joint_state.velocity.resize(joints.size(), std::numeric_limits<value_type>::quiet_NaN());
+  joint_state.effort.resize(joints.size(), std::numeric_limits<value_type>::quiet_NaN());
 
   for (std::size_t i = 0; i < joints.size(); ++i)
   {

--- a/joint_state_topic_hardware_interface/src/joint_state_topic_hardware_interface.cpp
+++ b/joint_state_topic_hardware_interface/src/joint_state_topic_hardware_interface.cpp
@@ -197,24 +197,33 @@ hardware_interface::return_type JointStateTopicSystem::write(const rclcpp::Time&
   }
 
   sensor_msgs::msg::JointState joint_state;
+
+  // The JointState message definition requires that all arrays in the message
+  // should have the same size, or be empty.
+  // https://docs.ros.org/en/api/sensor_msgs/html/msg/JointState.html
+  joint_state.name.resize(joints.size());
+  joint_state.position.resize(joints.size(), 0.0);
+  joint_state.velocity.resize(joints.size(), 0.0);
+  joint_state.effort.resize(joints.size(), 0.0);
+
   for (std::size_t i = 0; i < joints.size(); ++i)
   {
-    joint_state.name.push_back(joints[i].name);
     joint_state.header.stamp = get_node()->now();
+    joint_state.name[i] = joints[i].name;
     // only send commands to the interfaces that are defined for this joint
     for (const auto& interface : joints[i].command_interfaces)
     {
       if (interface.name == hardware_interface::HW_IF_POSITION)
       {
-        joint_state.position.push_back(get_command(joints[i].name + "/" + interface.name));
+        joint_state.position[i] = get_command(joints[i].name + "/" + interface.name);
       }
       else if (interface.name == hardware_interface::HW_IF_VELOCITY)
       {
-        joint_state.velocity.push_back(get_command(joints[i].name + "/" + interface.name));
+        joint_state.velocity[i] = get_command(joints[i].name + "/" + interface.name);
       }
       else if (interface.name == hardware_interface::HW_IF_EFFORT)
       {
-        joint_state.effort.push_back(get_command(joints[i].name + "/" + interface.name));
+        joint_state.effort[i] = get_command(joints[i].name + "/" + interface.name);
       }
       else
       {

--- a/joint_state_topic_hardware_interface/test/gripper/position.test.py
+++ b/joint_state_topic_hardware_interface/test/gripper/position.test.py
@@ -19,6 +19,7 @@ from pathlib import Path
 
 import launch_testing
 import launch_testing.markers
+import math
 import numpy as np
 import pytest
 import rclpy
@@ -106,11 +107,30 @@ class TestFixture(unittest.TestCase):
     def test_main(self, launch_service, proc_info, proc_output):
         # By default the joint_states should have the initial_value from rrr.urdf.xacro
         self.node.get_logger().info("Checking initial joint states...")
-        current_joint_state = self.get_current_joint_state()
+        current_joint_state, current_joint_state_msg = self.get_current_joint_state()
         urdf_initial_values = [0.15, 0.15]
         assert current_joint_state == urdf_initial_values, (
             f"{current_joint_state=} != {urdf_initial_values=}"
         )
+
+        # Check array sizes of joint_state message
+        assert len(current_joint_state_msg.position) == len(current_joint_state_msg.name), (
+            f"{len(current_joint_state_msg.position)=} != {len(current_joint_state_msg.name)=}"
+        )
+        assert len(current_joint_state_msg.velocity) == len(current_joint_state_msg.name), (
+            f"{len(current_joint_state_msg.velocity)=} != {len(current_joint_state_msg.name)=}"
+        )
+        assert len(current_joint_state_msg.effort) == len(current_joint_state_msg.effort), (
+            f"{len(current_joint_state_msg.effort)=} != {len(current_joint_state_msg.name)=}"
+        )
+
+        # Check velocity and effort arrays contain NaN
+        for cmd in current_joint_state_msg.velocity:
+            assert type(cmd) == float, (f"{type(cmd)=} != {float=}")
+            assert math.isnan(cmd), (f"{math.isnan(cmd)=}")
+        for cmd in current_joint_state_msg.effort:
+            assert type(cmd) == float, (f"{type(cmd)=} != {float=}")
+            assert math.isnan(cmd), (f"{math.isnan(cmd)=}")
 
         # Test setting the robot joint states via controller
         # test_gripper was not installed, call it directly from build space
@@ -132,7 +152,7 @@ class TestFixture(unittest.TestCase):
             )
 
         self.node.get_logger().info("Checking final joint states...")
-        current_joint_state = self.get_current_joint_state()
+        current_joint_state, _ = self.get_current_joint_state()
         final_values = [0.09, 0.09]
         assert np.allclose(
             current_joint_state,
@@ -142,9 +162,11 @@ class TestFixture(unittest.TestCase):
 
     def joint_states_callback(self, msg: JointState):
         self.current_joint_state = self.filter_joint_state_msg(msg)
+        self.current_joint_state_msg = msg
 
     def get_current_joint_state(self) -> OrderedDict[str, float]:
         """Get the current joint state reported by ros2_control on joint_states topic."""
+        self.current_joint_state_msg = None
         self.current_joint_state = []
         while len(self.current_joint_state) == 0:
             self.node.get_logger().warning(
@@ -153,7 +175,7 @@ class TestFixture(unittest.TestCase):
                 skip_first=True,
             )
             rclpy.spin_once(self.node, timeout_sec=1.0)
-        return self.current_joint_state
+        return self.current_joint_state, self.current_joint_state_msg
 
     def filter_joint_state_msg(self, msg: JointState):
         joint_states = []


### PR DESCRIPTION
JointState messages require the position, velocity and effort arrays are all the same size or empty in order to uniquely associate each joint name with the correct state. The current behaviour is to only push_back commands on the supported interfaces which can result in position, velocity and effort arrays of different sizes. This prevents the joint name from being uniquely associated with its corresponding command. 

### Example

This example is adapted from the `ackermann_drive_example` in `gz_ros2_control_demos` and uses the following control block.

```xml
  <ros2_control name="ackermann_joint_state_system" type="system">
    <hardware>
      <plugin>joint_state_topic_hardware_interface/JointStateTopicSystem</plugin>
      <param name="joint_commands_topic">/robot_joint_commands</param>
      <param name="joint_states_topic">/robot_joint_states</param>
    </hardware>
    <joint name="rear_left_wheel_joint">
      <command_interface name="velocity" />
      <state_interface name="velocity" />
      <state_interface name="position" />
      <state_interface name="effort" />
    </joint>
    <joint name="rear_right_wheel_joint">
      <command_interface name="velocity" />
      <state_interface name="position" />
      <state_interface name="velocity" />
      <state_interface name="effort" />
    </joint>
    <joint name="left_wheel_steering_joint">
      <command_interface name="position" />
      <state_interface name="position" />
      <state_interface name="velocity" />
      <state_interface name="effort" />
    </joint>
    <joint name="right_wheel_steering_joint">
      <command_interface name="position" />
      <state_interface name="position" />
      <state_interface name="velocity" />
      <state_interface name="effort" />
    </joint>
    <joint name="front_left_wheel_joint">
      <state_interface name="position" />
      <state_interface name="velocity" />
      <state_interface name="effort" />
    </joint>
    <joint name="front_right_wheel_joint">
      <state_interface name="position" />
      <state_interface name="velocity" />
      <state_interface name="effort" />
    </joint>
  </ros2_control>
```

Publish a twist to `/ackermann_steering_controller/reference` and inspect the output from the ackermann controller:

Before

```bash
ros2 topic echo -f /robot_joint_commands --once
header:
  stamp:
    sec: 31
    nanosec: 778000000
  frame_id: ''
name:
- rear_left_wheel_joint
- rear_right_wheel_joint
- left_wheel_steering_joint
- right_wheel_steering_joint
- front_left_wheel_joint
- front_right_wheel_joint
position:
- 0.0
- 0.0
velocity:
- 3.3330395022246466
- 3.3336271644420203
effort: []
---
```

After

```bash
ros2 topic echo -f /robot_joint_commands --once
header:
  stamp:
    sec: 1928
    nanosec: 134000000
  frame_id: ''
name:
- rear_left_wheel_joint
- rear_right_wheel_joint
- left_wheel_steering_joint
- right_wheel_steering_joint
- front_left_wheel_joint
- front_right_wheel_joint
position:
- 0.0
- 0.0
- 0.0
- 0.0
- 0.0
- 0.0
velocity:
- 3.3332697821011488
- 3.333396884565518
- 0.0
- 0.0
- 0.0
- 0.0
effort:
- 0.0
- 0.0
- 0.0
- 0.0
- 0.0
- 0.0
---
```

It may be better to initialise the command arrays with NaN to allow consumers of the message to differentiate between a command with value zero from one that is unset. The JointState message notes do not provide guidance on this.
