### PR TITLE
Publish JointState commands for velocity-only and effort-only interfaces

### DIFF
--- a/joint_state_topic_hardware_interface/src/joint_state_topic_hardware_interface.cpp
+++ b/joint_state_topic_hardware_interface/src/joint_state_topic_hardware_interface.cpp
@@ -182,7 +182,10 @@ hardware_interface::return_type JointStateTopicSystem::write(const rclcpp::Time&
   {
     for (const auto& interface : joints[i].command_interfaces)
     {
-      if (interface.name != hardware_interface::HW_IF_POSITION)
+      const bool supported_command_interface = interface.name == hardware_interface::HW_IF_POSITION ||
+                                               interface.name == hardware_interface::HW_IF_VELOCITY ||
+                                               interface.name == hardware_interface::HW_IF_EFFORT;
+      if (!supported_command_interface)
       {
         continue;
       }

--- a/joint_state_topic_hardware_interface/test/joint_state_topic_hardware_interface_test.cpp
+++ b/joint_state_topic_hardware_interface/test/joint_state_topic_hardware_interface_test.cpp
@@ -393,6 +393,67 @@ TEST_F(TestTopicBasedSystem, topic_based_system_2dof_velocity_only)
   EXPECT_EQ(j2_v_c.get_optional().value(), 0.14);
 }
 
+TEST_F(TestTopicBasedSystem, topic_based_system_2dof_position_only_publishes_commands)
+{
+  sensor_msgs::msg::JointState::SharedPtr command_msg;
+  auto command_subscriber = node_->create_subscription<sensor_msgs::msg::JointState>(
+      "/topic_based_joint_commands", rclcpp::QoS(1),
+      [&command_msg](const sensor_msgs::msg::JointState::SharedPtr msg) { command_msg = msg; });
+  executor_->add_node(node_);
+
+  const std::string hardware_system_2dof_topic_based =
+      R"(
+  <ros2_control name="JointStateTopicBasedSystem2dof" type="system">
+    <hardware>
+      <plugin>joint_state_topic_hardware_interface/JointStateTopicSystem</plugin>
+      <param name="joint_commands_topic">/topic_based_joint_commands</param>
+      <param name="joint_states_topic">/topic_based_custom_joint_states</param>
+    </hardware>
+    <joint name="joint1">
+      <command_interface name="position"/>
+      <state_interface name="position"/>
+    </joint>
+    <joint name="joint2">
+      <command_interface name="position"/>
+      <state_interface name="position"/>
+    </joint>
+  </ros2_control>
+)";
+  auto urdf =
+      ros2_control_test_assets::urdf_head + hardware_system_2dof_topic_based + ros2_control_test_assets::urdf_tail;
+
+  init_rm(urdf);
+
+  // Activate components to get all interfaces available
+  activate_components(*rm_, { "JointStateTopicBasedSystem2dof" });
+
+  hardware_interface::LoanedCommandInterface j1_p_c = rm_->claim_command_interface("joint1/position");
+  hardware_interface::LoanedCommandInterface j2_p_c = rm_->claim_command_interface("joint2/position");
+
+  ASSERT_TRUE(j1_p_c.set_value(0.12));
+  ASSERT_TRUE(j2_p_c.set_value(0.14));
+
+  int wait_count = 0;
+  while (node_->count_publishers("/topic_based_joint_commands") == 0 && wait_count < 5)
+  {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    ++wait_count;
+  }
+  ASSERT_GT(node_->count_publishers("/topic_based_joint_commands"), 0u);
+
+  hardware_interface::return_type ret;
+  ASSERT_NO_THROW(ret = rm_->write(TIME, PERIOD).result);
+  ASSERT_EQ(ret, hardware_interface::return_type::OK);
+
+  wait_for_msg(std::chrono::milliseconds{ 100 });
+
+  ASSERT_NE(command_msg, nullptr);
+  EXPECT_THAT(command_msg->name, ::testing::ElementsAre("joint1", "joint2"));
+  EXPECT_THAT(command_msg->position, ::testing::ElementsAre(0.12, 0.14));
+  EXPECT_TRUE(command_msg->velocity.empty());
+  EXPECT_TRUE(command_msg->effort.empty());
+}
+
 TEST_F(TestTopicBasedSystem, topic_based_system_2dof_velocity_only_publishes_commands)
 {
   sensor_msgs::msg::JointState::SharedPtr command_msg;

--- a/joint_state_topic_hardware_interface/test/joint_state_topic_hardware_interface_test.cpp
+++ b/joint_state_topic_hardware_interface/test/joint_state_topic_hardware_interface_test.cpp
@@ -393,6 +393,128 @@ TEST_F(TestTopicBasedSystem, topic_based_system_2dof_velocity_only)
   EXPECT_EQ(j2_v_c.get_optional().value(), 0.14);
 }
 
+TEST_F(TestTopicBasedSystem, topic_based_system_2dof_velocity_only_publishes_commands)
+{
+  sensor_msgs::msg::JointState::SharedPtr command_msg;
+  auto command_subscriber = node_->create_subscription<sensor_msgs::msg::JointState>(
+      "/topic_based_joint_commands", rclcpp::QoS(1),
+      [&command_msg](const sensor_msgs::msg::JointState::SharedPtr msg) { command_msg = msg; });
+  executor_->add_node(node_);
+
+  const std::string hardware_system_2dof_topic_based =
+      R"(
+  <ros2_control name="JointStateTopicBasedSystem2dof" type="system">
+    <hardware>
+      <plugin>joint_state_topic_hardware_interface/JointStateTopicSystem</plugin>
+      <param name="joint_commands_topic">/topic_based_joint_commands</param>
+      <param name="joint_states_topic">/topic_based_custom_joint_states</param>
+    </hardware>
+    <joint name="joint1">
+      <command_interface name="velocity"/>
+      <state_interface name="velocity"/>
+    </joint>
+    <joint name="joint2">
+      <command_interface name="velocity"/>
+      <state_interface name="velocity"/>
+    </joint>
+  </ros2_control>
+)";
+  auto urdf =
+      ros2_control_test_assets::urdf_head + hardware_system_2dof_topic_based + ros2_control_test_assets::urdf_tail;
+
+  init_rm(urdf);
+
+  // Activate components to get all interfaces available
+  activate_components(*rm_, { "JointStateTopicBasedSystem2dof" });
+
+  hardware_interface::LoanedCommandInterface j1_v_c = rm_->claim_command_interface("joint1/velocity");
+  hardware_interface::LoanedCommandInterface j2_v_c = rm_->claim_command_interface("joint2/velocity");
+
+  ASSERT_TRUE(j1_v_c.set_value(0.12));
+  ASSERT_TRUE(j2_v_c.set_value(0.14));
+
+  int wait_count = 0;
+  while (node_->count_publishers("/topic_based_joint_commands") == 0 && wait_count < 5)
+  {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    ++wait_count;
+  }
+  ASSERT_GT(node_->count_publishers("/topic_based_joint_commands"), 0u);
+
+  hardware_interface::return_type ret;
+  ASSERT_NO_THROW(ret = rm_->write(TIME, PERIOD).result);
+  ASSERT_EQ(ret, hardware_interface::return_type::OK);
+
+  wait_for_msg(std::chrono::milliseconds{ 100 });
+
+  ASSERT_NE(command_msg, nullptr);
+  EXPECT_THAT(command_msg->name, ::testing::ElementsAre("joint1", "joint2"));
+  EXPECT_TRUE(command_msg->position.empty());
+  EXPECT_THAT(command_msg->velocity, ::testing::ElementsAre(0.12, 0.14));
+  EXPECT_TRUE(command_msg->effort.empty());
+}
+
+TEST_F(TestTopicBasedSystem, topic_based_system_2dof_effort_only_publishes_commands)
+{
+  sensor_msgs::msg::JointState::SharedPtr command_msg;
+  auto command_subscriber = node_->create_subscription<sensor_msgs::msg::JointState>(
+      "/topic_based_joint_commands", rclcpp::QoS(1),
+      [&command_msg](const sensor_msgs::msg::JointState::SharedPtr msg) { command_msg = msg; });
+  executor_->add_node(node_);
+
+  const std::string hardware_system_2dof_topic_based =
+      R"(
+  <ros2_control name="JointStateTopicBasedSystem2dof" type="system">
+    <hardware>
+      <plugin>joint_state_topic_hardware_interface/JointStateTopicSystem</plugin>
+      <param name="joint_commands_topic">/topic_based_joint_commands</param>
+      <param name="joint_states_topic">/topic_based_custom_joint_states</param>
+    </hardware>
+    <joint name="joint1">
+      <command_interface name="effort"/>
+      <state_interface name="effort"/>
+    </joint>
+    <joint name="joint2">
+      <command_interface name="effort"/>
+      <state_interface name="effort"/>
+    </joint>
+  </ros2_control>
+)";
+  auto urdf =
+      ros2_control_test_assets::urdf_head + hardware_system_2dof_topic_based + ros2_control_test_assets::urdf_tail;
+
+  init_rm(urdf);
+
+  // Activate components to get all interfaces available
+  activate_components(*rm_, { "JointStateTopicBasedSystem2dof" });
+
+  hardware_interface::LoanedCommandInterface j1_e_c = rm_->claim_command_interface("joint1/effort");
+  hardware_interface::LoanedCommandInterface j2_e_c = rm_->claim_command_interface("joint2/effort");
+
+  ASSERT_TRUE(j1_e_c.set_value(0.12));
+  ASSERT_TRUE(j2_e_c.set_value(0.14));
+
+  int wait_count = 0;
+  while (node_->count_publishers("/topic_based_joint_commands") == 0 && wait_count < 5)
+  {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    ++wait_count;
+  }
+  ASSERT_GT(node_->count_publishers("/topic_based_joint_commands"), 0u);
+
+  hardware_interface::return_type ret;
+  ASSERT_NO_THROW(ret = rm_->write(TIME, PERIOD).result);
+  ASSERT_EQ(ret, hardware_interface::return_type::OK);
+
+  wait_for_msg(std::chrono::milliseconds{ 100 });
+
+  ASSERT_NE(command_msg, nullptr);
+  EXPECT_THAT(command_msg->name, ::testing::ElementsAre("joint1", "joint2"));
+  EXPECT_TRUE(command_msg->position.empty());
+  EXPECT_TRUE(command_msg->velocity.empty());
+  EXPECT_THAT(command_msg->effort, ::testing::ElementsAre(0.12, 0.14));
+}
+
 TEST_F(TestTopicBasedSystem, topic_based_system_2dof_velocity_only_inconsistent_topic)
 {
   const std::string hardware_system_2dof_topic_based =


### PR DESCRIPTION
<!--
Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:

1. Limited scope. Your PR should do one thing or one set of things. Avoid adding “random fixes” to PRs. Put those on separate PRs.
2. Give your PR a descriptive title. Add a short summary, if required.
3. Make sure the pipeline is green.
4. New code = new tests. If you are adding new functionality, always make sure to add some tests exercising the code and serving as live documentation of your original intention.
5. If a PR is merged all commits will get squashed, a linear commit history is not required.
6. Once a PR got reviewed, please don't do force pushes as this will break github UI and subsequent reviews will take more time.
-->

## Description
Fixes the `JointStateTopicSystem::write()` publish threshold so it considers all supported command interfaces, not just `position`.

Previously, the rate limiter only accumulated command/state differences for `position` interfaces. Velocity-only and effort-only hardware configurations could update command values without publishing a `sensor_msgs/msg/JointState` command message.

This PR updates the threshold check to include:

- `position`
- `velocity`
- `effort`

It also adds regression tests covering position-only, velocity-only, and effort-only command publishing.

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

### Is this user-facing behavior change?
Yes. Users with velocity-only or effort-only command interfaces should now see command messages published on the configured `joint_commands_topic` when those command values change beyond the trigger threshold.

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?
Yes. I used OpenAI Codex to help implement the fix, add regression tests, and run local verification.

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information
Regression check: with the new tests applied but the production fix reverted to the pre-fix implementation, the velocity-only and effort-only publish tests fail because no `JointState` command message is received:
```bash
    [----------] Global test environment tear-down
    [==========] 8 tests from 1 test suite ran. (483 ms total)
    [  PASSED  ] 6 tests.
    [  FAILED  ] 2 tests, listed below:
    [  FAILED  ] TestTopicBasedSystem.topic_based_system_2dof_velocity_only_publishes_commands
    [  FAILED  ] TestTopicBasedSystem.topic_based_system_2dof_effort_only_publishes_commands

```

With the fix restored, local verification passes:

```bash
Summary: 9 tests, 0 errors, 0 failures, 0 skipped
```
<!--
If applicable, provide any additional context or details about the changes.
-->

## TODOs

To send us a pull request, please:

- [x] Fork the repository.
- [x] Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
- [x] Ensure local tests pass. (`colcon test` and `pre-commit run` (requires you to install pre-commit by `pip3 install pre-commit`)
- [x] Commit to your fork using clear commit messages.
- [x] Send a pull request, answering any default questions in the pull request interface.
- [x] Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
